### PR TITLE
Remove unneeded backtrace field from errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Removed the explicit backtrace field from the errors when run under the
+nightly toolchain. This appears to not be needed as eyre is still able to
+get the error backtrace without it on both nightly and stable.
+
 ## [0.1.0-RC2] 2022-10-29
 ### Changed
 - Removed the "reqwest-" prefix from the TLS feature flags. The old TLS

--- a/src/errors/client_errors.rs
+++ b/src/errors/client_errors.rs
@@ -1,74 +1,35 @@
 //! Error types for the [Client](crate::client) module.
 
-#[cfg(feature = "nightly")]
-use std::backtrace::Backtrace;
-
 use thiserror::Error;
 
 use crate::client::client_helpers::Client;
 
 
-// cfg_if::cfg_if! {
-//     if #[cfg(feature = "nightly")] {
-//         #[derive(Error, Debug)]
-//         #[error("Failed to create a proxy for reqwest")]
-//         pub struct ProxyConvertError {
-//             #[from]
-//             source: reqwest::Error,
-//             backtrace: Backtrace,
-//         }
-//     } else {
-//         #[derive(Error, Debug)]
-//         #[error("Failed to create a proxy for reqwest")]
-//         pub struct ProxyConvertError {
-//             #[from]
-//             source: reqwest::Error,
-//         }
-//     }
+// #[derive(Error, Debug)]
+// #[error("Failed to create a proxy for reqwest")]
+// pub struct ProxyConvertError {
+//     #[from]
+//     source: reqwest::Error,
 // }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        /// Inner error type for [ClientRegistrationError]
-        #[derive(Error, Debug)]
-        pub enum ClientRegistrationInnerError {
-            #[error("Failed to send the request to the server")]
-            RequestSendFailure {
-                #[from]
-                source: reqwest::Error,
-                backtrace: Backtrace,
-            },
+/// Inner error type for [ClientRegistrationError]
+#[derive(Error, Debug)]
+pub enum ClientRegistrationInnerError {
+    #[error("Failed to send the request to the server")]
+    RequestSendFailure {
+        #[from]
+        source: reqwest::Error,
+    },
 
-            #[error("Server returned an Unauthorized status code")]
-            Unauthorized,
+    #[error("Server returned an Unauthorized status code")]
+    Unauthorized,
 
-            #[error("Failed to register with the server - {status_code}: {server_msg}")]
-            RegistrationFailure {
-                server_msg: String,
-                status_code: u16,
-            },
-        }
-    } else {
-        /// Inner error type for [ClientRegistrationError]
-        #[derive(Error, Debug)]
-        pub enum ClientRegistrationInnerError {
-            #[error("Failed to send the request to the server")]
-            RequestSendFailure {
-                #[from]
-                source: reqwest::Error,
-            },
-
-            #[error("Server returned an Unauthorized status code")]
-            Unauthorized,
-
-            #[error("Failed to register with the server - {status_code}: {server_msg}")]
-            RegistrationFailure {
-                server_msg: String,
-                status_code: u16,
-            },
-        }
-    }
+    #[error("Failed to register with the server - {status_code}: {server_msg}")]
+    RegistrationFailure {
+        server_msg: String,
+        status_code: u16,
+    },
 }
 
 
@@ -93,176 +54,80 @@ where
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        /// The error type used by the [ClientBuilder](crate::client::ClientBuilder)
-        #[derive(Error, Debug)]
-        pub enum ClientBuildError {
-            // #[error("Failed to set proxy")]
-            // InvalidProxy {
-            //     #[from]
-            //     source: ProxyConvertError,
-            //     backtrace: Backtrace,
-            // },
+/// The error type used by the [ClientBuilder](crate::client::ClientBuilder)
+#[derive(Error, Debug)]
+pub enum ClientBuildError {
+    // #[error("Failed to set proxy")]
+    // InvalidProxy {
+    //     #[from]
+    //     source: ProxyConvertError,
+    // },
+    #[error("Builder failed to generate the RSA private key")]
+    RsaGen {
+        #[from]
+        source: super::RsaGenError,
+    },
 
-            #[error("Builder failed to generate the RSA private key")]
-            RsaGen {
-                #[from]
-                source: super::RsaGenError,
-                backtrace: Backtrace,
-            },
+    #[error("RSA key size was not set")]
+    MissingRsaKeySize,
 
-            #[error("RSA key size was not set")]
-            MissingRsaKeySize,
+    #[error("Interactsh server was not set")]
+    MissingServer,
 
-            #[error("Interactsh server was not set")]
-            MissingServer,
+    #[error("Failed to extract the RSA public key")]
+    PubKeyExtract {
+        #[from]
+        source: super::RsaGetPubKeyError,
+    },
 
-            #[error("Failed to extract the RSA public key")]
-            PubKeyExtract {
-                #[from]
-                source: super::RsaGetPubKeyError,
-                backtrace: Backtrace,
-            },
+    #[error("Failed to encode the RSA public key")]
+    PubKeyEncode {
+        #[from]
+        source: super::RsaEncodePubKeyError,
+    },
 
-            #[error("Failed to encode the RSA public key")]
-            PubKeyEncode {
-                #[from]
-                source: super::RsaEncodePubKeyError,
-                backtrace: Backtrace,
-            },
-
-            #[error("Failed to build the reqwest client")]
-            ReqwestBuildFailed {
-                #[from]
-                source: reqwest::Error,
-                backtrace: Backtrace,
-            },
-        }
-    } else {
-        /// The error type used by the [ClientBuilder](crate::client::ClientBuilder)
-        #[derive(Error, Debug)]
-        pub enum ClientBuildError {
-            // #[error("Failed to set proxy")]
-            // InvalidProxy {
-            //     #[from]
-            //     source: ProxyConvertError,
-            // },
-
-            #[error("Builder failed to generate the RSA private key")]
-            RsaGen {
-                #[from]
-                source: super::RsaGenError,
-            },
-
-            #[error("RSA key size was not set")]
-            MissingRsaKeySize,
-
-            #[error("Interactsh server was not set")]
-            MissingServer,
-
-            #[error("Failed to extract the RSA public key")]
-            PubKeyExtract {
-                #[from]
-                source: super::RsaGetPubKeyError,
-            },
-
-            #[error("Failed to encode the RSA public key")]
-            PubKeyEncode {
-                #[from]
-                source: super::RsaEncodePubKeyError,
-            },
-
-            #[error("Failed to build the reqwest client")]
-            ReqwestBuildFailed {
-                #[from]
-                source: reqwest::Error,
-            },
-        }
-    }
+    #[error("Failed to build the reqwest client")]
+    ReqwestBuildFailed {
+        #[from]
+        source: reqwest::Error,
+    },
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        /// The error type used by the [RegisteredClient](crate::client::RegisteredClient)
-        /// when polling the server
-        #[derive(Error, Debug)]
-        pub enum ClientPollError {
-            #[error("Client failed to deregister with the Interactsh server")]
-            Deregister,
+/// The error type used by the [RegisteredClient](crate::client::RegisteredClient)
+/// when polling the server
+#[derive(Error, Debug)]
+pub enum ClientPollError {
+    #[error("Client failed to deregister with the Interactsh server")]
+    Deregister,
 
-            #[error("Client failed to poll the Interactsh server")]
-            PollFailure {
-                #[from]
-                source: reqwest::Error,
-                backtrace: Backtrace,
-            },
+    #[error("Client failed to poll the Interactsh server")]
+    PollFailure {
+        #[from]
+        source: reqwest::Error,
+    },
 
-            #[error("Interactsh server returned error status - {status_code}: {server_msg}")]
-            PollError {
-                server_msg: String,
-                status_code: u16,
-            },
+    #[error("Interactsh server returned error status - {status_code}: {server_msg}")]
+    PollError {
+        server_msg: String,
+        status_code: u16,
+    },
 
-            #[error("Failed to decrypt the AES key")]
-            AesKeyDecryptFailed {
-                #[from]
-                source: super::RsaDecryptError,
-                backtrace: Backtrace,
-            },
+    #[error("Failed to decrypt the AES key")]
+    AesKeyDecryptFailed {
+        #[from]
+        source: super::RsaDecryptError,
+    },
 
-            #[error("Failed to decrypt the received data")]
-            DataDecryptFailed {
-                #[from]
-                source: super::AesDecryptError,
-                backtrace: Backtrace,
-            },
+    #[error("Failed to decrypt the received data")]
+    DataDecryptFailed {
+        #[from]
+        source: super::AesDecryptError,
+    },
 
-            #[error("Base64 decoding failed")]
-            Base64DecodeFailed {
-                #[from]
-                source: base64::DecodeError,
-                backtrace: Backtrace,
-            },
-        }
-    } else {
-        /// The error type used by the [RegisteredClient](crate::client::RegisteredClient)
-        /// when polling the server
-        #[derive(Error, Debug)]
-        pub enum ClientPollError {
-            #[error("Client failed to deregister with the Interactsh server")]
-            Deregister,
-
-            #[error("Client failed to poll the Interactsh server")]
-            PollFailure {
-                #[from]
-                source: reqwest::Error,
-            },
-
-            #[error("Interactsh server returned error status - {status_code}: {server_msg}")]
-            PollError {
-                server_msg: String,
-                status_code: u16,
-            },
-
-            #[error("Failed to decrypt the AES key")]
-            AesKeyDecryptFailed {
-                #[from]
-                source: super::RsaDecryptError,
-            },
-
-            #[error("Failed to decrypt the received data")]
-            DataDecryptFailed {
-                #[from]
-                source: super::AesDecryptError,
-            },
-
-            #[error("Base64 decoding failed")]
-            Base64DecodeFailed {
-                #[from]
-                source: base64::DecodeError,
-            },
-        }
-    }
+    #[error("Base64 decoding failed")]
+    Base64DecodeFailed {
+        #[from]
+        source: base64::DecodeError,
+    },
 }

--- a/src/errors/openssl_errors.rs
+++ b/src/errors/openssl_errors.rs
@@ -1,154 +1,65 @@
 //! The error types used by the [crypto](crate::crypto) module when the
 //! `openssl` feature is enabled (and `rustcrypto` is not enabled)
 
-#[cfg(feature = "nightly")]
-use std::backtrace::Backtrace;
-
 use thiserror::Error;
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        pub enum AesDecryptError {
-            #[error("Unable to decrypt data with provided AES key")]
-            DecryptFailure {
-                #[from]
-                source: openssl::error::ErrorStack,
-                backtrace: Backtrace,
-            },
+#[derive(Error, Debug)]
+pub enum AesDecryptError {
+    #[error("Unable to decrypt data with provided AES key")]
+    DecryptFailure {
+        #[from]
+        source: openssl::error::ErrorStack,
+    },
 
-            #[error("Failed to decode the data using base 64 encoding")]
-            DecodeFailure {
-                #[from]
-                source: base64::DecodeError,
-                backtrace: Backtrace,
-            }
-        }
-    } else {
-        #[derive(Error, Debug)]
-        pub enum AesDecryptError {
-            #[error("Unable to decrypt data with provided AES key")]
-            DecryptFailure {
-                #[from]
-                source: openssl::error::ErrorStack,
-            },
-
-            #[error("Failed to decode the data using base 64 encoding")]
-            DecodeFailure {
-                #[from]
-                source: base64::DecodeError,
-            }
-        }
-    }
+    #[error("Failed to decode the data using base 64 encoding")]
+    DecodeFailure {
+        #[from]
+        source: base64::DecodeError,
+    },
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        pub enum RsaGenInnerError {
-            #[error("Requested RSA key bit size is too large")]
-            BitSize,
+#[derive(Error, Debug)]
+pub enum RsaGenInnerError {
+    #[error("Requested RSA key bit size is too large")]
+    BitSize,
 
-            #[error("OpenSSL failed to generate the RSA private key")]
-            OpenSsl {
-                #[from]
-                source: openssl::error::ErrorStack,
-                backtrace: Backtrace,
-            },
-        }
-    } else {
-        #[derive(Error, Debug)]
-        pub enum RsaGenInnerError {
-            #[error("Requested RSA key bit size is too large")]
-            BitSize,
-
-            #[error("OpenSSL failed to generate the RSA private key")]
-            OpenSsl {
-                #[from]
-                source: openssl::error::ErrorStack,
-            },
-        }
-    }
+    #[error("OpenSSL failed to generate the RSA private key")]
+    OpenSsl {
+        #[from]
+        source: openssl::error::ErrorStack,
+    },
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to generate the RSA private key")]
-        pub struct RsaGenError {
-            #[from]
-            source: RsaGenInnerError,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to generate the RSA private key")]
-        pub struct RsaGenError {
-            #[from]
-            source: RsaGenInnerError,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to generate the RSA private key")]
+pub struct RsaGenError {
+    #[from]
+    source: RsaGenInnerError,
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to decrypt the data with the provided RSA private key")]
-        pub struct RsaDecryptError {
-            #[from]
-            source: openssl::error::ErrorStack,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to decrypt the data with the provided RSA private key")]
-        pub struct RsaDecryptError {
-            #[from]
-            source: openssl::error::ErrorStack,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to decrypt the data with the provided RSA private key")]
+pub struct RsaDecryptError {
+    #[from]
+    source: openssl::error::ErrorStack,
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to extract the RSA public key from the RSA private key")]
-        pub struct RsaGetPubKeyError {
-            #[from]
-            source: openssl::error::ErrorStack,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to extract the RSA public key from the RSA private key")]
-        pub struct RsaGetPubKeyError {
-            #[from]
-            source: openssl::error::ErrorStack,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to extract the RSA public key from the RSA private key")]
+pub struct RsaGetPubKeyError {
+    #[from]
+    source: openssl::error::ErrorStack,
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to encode the RSA public key as a base 64 string")]
-        pub struct RsaEncodePubKeyError {
-            #[from]
-            source: openssl::error::ErrorStack,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to encode the RSA public key as a base 64 string")]
-        pub struct RsaEncodePubKeyError {
-            #[from]
-            source: openssl::error::ErrorStack,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to encode the RSA public key as a base 64 string")]
+pub struct RsaEncodePubKeyError {
+    #[from]
+    source: openssl::error::ErrorStack,
 }

--- a/src/errors/rustcrypto_errors.rs
+++ b/src/errors/rustcrypto_errors.rs
@@ -1,86 +1,38 @@
 //! The error types used by the [crypto](crate::crypto) module when the
 //! `rustcrypto` feature is enabled
 
-#[cfg(feature = "nightly")]
-use std::backtrace::Backtrace;
-
 use thiserror::Error;
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        pub enum AesDecryptError {
-            #[error("Unable to decrypt data with provided AES key")]
-            DecryptFailure {
-                #[from]
-                source: inout::NotEqualError,
-                backtrace: Backtrace,
-            },
+#[derive(Error, Debug)]
+pub enum AesDecryptError {
+    #[error("Unable to decrypt data with provided AES key")]
+    DecryptFailure {
+        #[from]
+        source: inout::NotEqualError,
+    },
 
-            #[error("Failed to decode the data using base 64 encoding")]
-            DecodeFailure {
-                #[from]
-                source: base64::DecodeError,
-                backtrace: Backtrace,
-            }
-        }
-    } else {
-        #[derive(Error, Debug)]
-        pub enum AesDecryptError {
-            #[error("Unable to decrypt data with provided AES key")]
-            DecryptFailure {
-                #[from]
-                source: inout::NotEqualError,
-            },
-
-            #[error("Failed to decode the data using base 64 encoding")]
-            DecodeFailure {
-                #[from]
-                source: base64::DecodeError,
-            }
-        }
-    }
+    #[error("Failed to decode the data using base 64 encoding")]
+    DecodeFailure {
+        #[from]
+        source: base64::DecodeError,
+    },
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to generate the RSA private key")]
-        pub struct RsaGenError {
-            #[from]
-            source: rsa::errors::Error,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to generate the RSA private key")]
-        pub struct RsaGenError {
-            #[from]
-            source: rsa::errors::Error,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to generate the RSA private key")]
+pub struct RsaGenError {
+    #[from]
+    source: rsa::errors::Error,
 }
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to decrypt the data with the provided RSA private key")]
-        pub struct RsaDecryptError {
-            #[from]
-            source: rsa::errors::Error,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to decrypt the data with the provided RSA private key")]
-        pub struct RsaDecryptError {
-            #[from]
-            source: rsa::errors::Error,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to decrypt the data with the provided RSA private key")]
+pub struct RsaDecryptError {
+    #[from]
+    source: rsa::errors::Error,
 }
 
 
@@ -89,21 +41,9 @@ cfg_if::cfg_if! {
 pub struct RsaGetPubKeyError;
 
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[derive(Error, Debug)]
-        #[error("Failed to encode the RSA public key as a base 64 string")]
-        pub struct RsaEncodePubKeyError {
-            #[from]
-            source: rsa::pkcs8::spki::Error,
-            backtrace: Backtrace,
-        }
-    } else {
-        #[derive(Error, Debug)]
-        #[error("Failed to encode the RSA public key as a base 64 string")]
-        pub struct RsaEncodePubKeyError {
-            #[from]
-            source: rsa::pkcs8::spki::Error,
-        }
-    }
+#[derive(Error, Debug)]
+#[error("Failed to encode the RSA public key as a base 64 string")]
+pub struct RsaEncodePubKeyError {
+    #[from]
+    source: rsa::pkcs8::spki::Error,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,6 @@
 //! (enabled by default).
 
 #![cfg_attr(feature = "nightly", feature(doc_auto_cfg))]
-#![cfg_attr(feature = "nightly", feature(error_generic_member_access))]
-#![cfg_attr(feature = "nightly", feature(provide_any))]
 
 #[cfg(any(feature = "rustcrypto", feature = "openssl"))]
 pub(crate) mod crypto;


### PR DESCRIPTION
The backtrace field on the errors appears to be unneeded as eyre is still able to get the backtrace on stable and nightly with the field removed. Removing this field cuts down on the error complexity since it was only available on the nightly toolchain.

Leaving this as a draft until I confirm that everything still works as intended.